### PR TITLE
Specify runtime

### DIFF
--- a/deploy/aws/buildspec_build.yml
+++ b/deploy/aws/buildspec_build.yml
@@ -1,6 +1,8 @@
 version: 0.2
 phases:
   install:
+    runtime-versions:
+      docker: 18
     commands:
        - apt install -y make
        - curl -o aws-iam-authenticator https://amazon-eks.s3-us-west-2.amazonaws.com/1.12.7/2019-03-27/bin/linux/amd64/aws-iam-authenticator


### PR DESCRIPTION
The [codebuild](https://console.aws.amazon.com/codesuite/codebuild/projects/default-fluentd-build/build/default-fluentd-build%3Ab30c6faf-1c95-4ce0-98aa-1da459a2e9e8/log?region=us-east-1) is failing with:

```
[Container] 2019/11/13 21:32:52 Phase context status code: YAML_FILE_ERROR Message: This build image requires selecting at least one runtime version. 
```